### PR TITLE
No more policydb validation

### DIFF
--- a/libsepol/src/policydb.c
+++ b/libsepol/src/policydb.c
@@ -4569,9 +4569,6 @@ int policydb_read(policydb_t * p, struct policy_file *fp, unsigned verbose)
 		}
 	}
 
-	if (policydb_validate(fp->handle, p))
-		goto bad;
-
 	return POLICYDB_SUCCESS;
       bad:
 	return POLICYDB_ERROR;


### PR DESCRIPTION
Validation is useless in magiskpolicy's use case, and now it turns out the new more strict validation breaks compatibility with some existing devices, so skip it.

Close #3 